### PR TITLE
Check backend frontend redis communication

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: redis:2
     ports:
       - "6379:6379"
+      - "6380:6379"
     command: redis-server --requirepass pass123
     networks:
       - qt_trade_network


### PR DESCRIPTION
Expose Redis on host port 6380 to enable frontend connectivity.

---
<a href="https://cursor.com/background-agent?bcId=bc-336ee96b-a860-4cf9-868c-869f321a8b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-336ee96b-a860-4cf9-868c-869f321a8b80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

